### PR TITLE
[BUG]Using kubejs the structures is not recognized if /reload is not …

### DIFF
--- a/src/main/java/io/ticticboom/mods/mm/mixin/ServerLifecycleHooksMixin.java
+++ b/src/main/java/io/ticticboom/mods/mm/mixin/ServerLifecycleHooksMixin.java
@@ -1,0 +1,18 @@
+package io.ticticboom.mods.mm.mixin;
+
+import io.ticticboom.mods.mm.structure.StructureManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.server.ServerLifecycleHooks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerLifecycleHooks.class)
+public class ServerLifecycleHooksMixin {
+
+    @Inject(method = "handleServerStarted", at = @At("TAIL"), remap = false)
+    private static void handleServerStarted(MinecraftServer server, CallbackInfo ci) {
+        StructureManager.validateAllPieces();
+    }
+}

--- a/src/main/java/io/ticticboom/mods/mm/piece/type/block/BlockStructurePiece.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/type/block/BlockStructurePiece.java
@@ -36,6 +36,10 @@ public class BlockStructurePiece extends StructurePiece {
 
     @Override
     public boolean formed(Level level, BlockPos pos, StructureModel model) {
+        //just in case if block was not initialized yet
+        if(block == null) {
+            block = ForgeRegistries.BLOCKS.getValue(blockId);
+        }
         return level.getBlockState(pos).is(block);
     }
 

--- a/src/main/resources/mixins.mm.json
+++ b/src/main/resources/mixins.mm.json
@@ -5,6 +5,7 @@
   "refmap": "mm.refmap.json",
   "mixins": [
     "DediServerMixin",
+    "ServerLifecycleHooksMixin",
     "ServerMixin"
   ],
   "minVersion": "0.8"


### PR DESCRIPTION
…executed #86

i don't know why ServerStartedEvent listener didn't work. 
It was unable to start due to "reading config before initialized" thing.
This is why i came with mixin

