### PR TITLE
fix(jei): prevent tooltip insertion OOB crash in structure recipe view

### DIFF
--- a/src/main/java/io/ticticboom/mods/mm/compat/jei/category/MMStructureCategory.java
+++ b/src/main/java/io/ticticboom/mods/mm/compat/jei/category/MMStructureCategory.java
@@ -79,7 +79,9 @@ public class MMStructureCategory implements IRecipeCategory<StructureModel> {
             var slot = builder.addSlot(RecipeIngredientRole.INPUT, next.x, next.y);
             slot.addItemStacks(countedItemStack.getStacks());
             slot.addTooltipCallback((a, b) -> {
-                b.add(b.size() - 2, countedItemStack.getDetail());
+                int size = b.size();
+                int insertIndex = (size >= 2) ? (size - 2) : size;
+                b.add(insertIndex, countedItemStack.getDetail());
             });
         }
 


### PR DESCRIPTION
Fix crash when hovering JEI structure recipe slots due to inserting tooltip at size - 2 when size < 2.
Now: insert at size - 2 if size >= 2, otherwise append at end.
File: 
io/ticticboom/mods/mm/compat/jei/category/MMStructureCategory.java
Verified: no crash; layout preserved when enough lines.
[crash-2025-09-03_11.55.04-client.txt](https://github.com/user-attachments/files/22108713/crash-2025-09-03_11.55.04-client.txt)
