### PR TITLE
Run structure validation in async threads and other optimizations

### DIFF
--- a/src/main/java/io/ticticboom/mods/mm/config/MMCommonConfig.java
+++ b/src/main/java/io/ticticboom/mods/mm/config/MMCommonConfig.java
@@ -7,10 +7,13 @@ public class MMCommonConfig {
     public final ForgeConfigSpec.BooleanValue splitRecipesJei;
     public final ForgeConfigSpec.BooleanValue portsAutoExtractByDefault;
     public final ForgeConfigSpec.BooleanValue asyncStructureValidation;
+    public final ForgeConfigSpec.IntValue structureValidationRate;
 
     public MMCommonConfig(ForgeConfigSpec.Builder builder) {
         asyncStructureValidation = builder.comment("Enables async structure validation to improve TPS. Disable in case of issues.")
                 .define("asyncValidation", true);
+        structureValidationRate = builder.comment("How often controller will check structure. 1 means every tick, 20 means every second.")
+                .defineInRange("structureValidationRate", 10, 1, 100);
         debugTool = builder.comment("Enables the Debug Tool Item's functionality (Disable when on server)")
                 .define("debugTool", true);
         splitRecipesJei = builder.comment("Splits JEI recipe viewer categroies by the structure they belong to.")

--- a/src/main/java/io/ticticboom/mods/mm/config/MMCommonConfig.java
+++ b/src/main/java/io/ticticboom/mods/mm/config/MMCommonConfig.java
@@ -6,8 +6,11 @@ public class MMCommonConfig {
     public final ForgeConfigSpec.BooleanValue debugTool;
     public final ForgeConfigSpec.BooleanValue splitRecipesJei;
     public final ForgeConfigSpec.BooleanValue portsAutoExtractByDefault;
+    public final ForgeConfigSpec.BooleanValue asyncStructureValidation;
 
     public MMCommonConfig(ForgeConfigSpec.Builder builder) {
+        asyncStructureValidation = builder.comment("Enables async structure validation to improve TPS. Disable in case of issues.")
+                .define("asyncValidation", true);
         debugTool = builder.comment("Enables the Debug Tool Item's functionality (Disable when on server)")
                 .define("debugTool", true);
         splitRecipesJei = builder.comment("Splits JEI recipe viewer categroies by the structure they belong to.")

--- a/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlock.java
@@ -8,8 +8,10 @@ import io.ticticboom.mods.mm.model.ControllerModel;
 import io.ticticboom.mods.mm.port.kinetic.register.CreateKineticGenPortBlockEntity;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.util.BlockUtils;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -83,7 +85,7 @@ public class MachineControllerBlock extends HorizontalDirectionalBlock implement
 
     @Override
     public void onRemove(BlockState p_60515_, Level level, BlockPos pos, BlockState p_60518_, boolean p_60519_) {
-        var be = level.getBlockEntity(pos);
+        var be = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (be instanceof MachineControllerBlockEntity mbe) {
             mbe.invalidateProgress();
         }

--- a/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
@@ -78,10 +78,12 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
     }
 
     private void runMachineTick() {
-        if(COMMON.asyncStructureValidation.get()) {
-            validateStructureAsync(getLevel());
-        } else {
-            validateStructure(getLevel());
+        if(!isFormed || level.getGameTime() % COMMON.structureValidationRate.get() == 0){
+            if (COMMON.asyncStructureValidation.get()) {
+                validateStructureAsync(getLevel());
+            } else {
+                validateStructure(getLevel());
+            }
         }
         if (isFormed) {
             runRecipe();
@@ -216,11 +218,7 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
         }
 
         if (!canContinueRecipe()) {
-            for (RecipeModel recipe : MachineRecipeManager.RECIPES.values()) {
-                if (!recipe.structureId().equals(structure.id())) {
-                    continue;
-                }
-
+            for (RecipeModel recipe : MachineRecipeManager.getRecipesByStrucutreId(structure.id())) {
                 if (recipe.canProcess(level, recipeState, portStorages)) {
                     setChanged();
                     currentRecipe = recipe;

--- a/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
@@ -38,9 +38,9 @@ import static io.ticticboom.mods.mm.config.MMConfigSetup.COMMON;
 public class MachineControllerBlockEntity extends BlockEntity implements IControllerBlockEntity, IControllerPart {
     private static final Executor STRUCTURE_VALIDATION_EXECUTOR = Executors.newFixedThreadPool(
         Math.max(2, Runtime.getRuntime().availableProcessors() / 2), r -> {
-        Thread thread = new Thread(r, "MM-StructureValidation");
+        Thread thread = new Thread(r, "MM-Structures");
         thread.setDaemon(true);
-        thread.setPriority(Thread.NORM_PRIORITY - 1); // Lower priority than main thread
+        thread.setPriority(Thread.MAX_PRIORITY - 1);
         return thread;
     });
     

--- a/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
@@ -176,9 +176,10 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
 
     private void updateStructureValidationResults(boolean newIsFormed, StructureModel newStructure) {
         boolean structureChanged = false;
-
+        portStorages = null;
         if (structure != newStructure) {
             structure = newStructure;
+            portStorages = structure.getStorages(level, getBlockPos());
             structureChanged = true;
         }
 
@@ -259,7 +260,6 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
         if (currentRecipe != null && !typical && portStorages != null) {
             currentRecipe.ditchRecipe(this.level, recipeState, portStorages);
         }
-        portStorages = null;
         recipeState = null;
         currentRecipe = null;
     }

--- a/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/controller/machine/register/MachineControllerBlockEntity.java
@@ -176,10 +176,9 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
 
     private void updateStructureValidationResults(boolean newIsFormed, StructureModel newStructure) {
         boolean structureChanged = false;
-        portStorages = null;
+
         if (structure != newStructure) {
             structure = newStructure;
-            portStorages = structure.getStorages(level, getBlockPos());
             structureChanged = true;
         }
 
@@ -260,6 +259,7 @@ public class MachineControllerBlockEntity extends BlockEntity implements IContro
         if (currentRecipe != null && !typical && portStorages != null) {
             currentRecipe.ditchRecipe(this.level, recipeState, portStorages);
         }
+        portStorages = null;
         recipeState = null;
         currentRecipe = null;
     }

--- a/src/main/java/io/ticticboom/mods/mm/piece/modifier/blockstate/BlockstateStructurePieceModifier.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/modifier/blockstate/BlockstateStructurePieceModifier.java
@@ -7,7 +7,9 @@ import io.ticticboom.mods.mm.Ref;
 import io.ticticboom.mods.mm.piece.StructurePieceSetupMetadata;
 import io.ticticboom.mods.mm.piece.modifier.StructurePieceModifier;
 import io.ticticboom.mods.mm.structure.StructureModel;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Rotation;
@@ -49,7 +51,7 @@ public class BlockstateStructurePieceModifier extends StructurePieceModifier {
 
     @Override
     public boolean formed(Level level, BlockPos pos, StructureModel model, Rotation rotation) {
-        BlockState blockState = level.getBlockState(pos);
+        BlockState blockState = WorldUtil.getBlockState(pos, (ServerLevel) level);
         var matched = new AtomicInteger();
         for (Property.Value<?> value : propValues.values()) {
             var prop = blockState.getOptionalValue(value.property());

--- a/src/main/java/io/ticticboom/mods/mm/piece/type/block/BlockStructurePiece.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/type/block/BlockStructurePiece.java
@@ -5,10 +5,12 @@ import io.ticticboom.mods.mm.piece.StructurePieceSetupMetadata;
 import io.ticticboom.mods.mm.piece.type.StructurePiece;
 import io.ticticboom.mods.mm.util.StructurePieceUtils;
 import io.ticticboom.mods.mm.structure.StructureModel;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -40,7 +42,7 @@ public class BlockStructurePiece extends StructurePiece {
         if(block == null) {
             block = ForgeRegistries.BLOCKS.getValue(blockId);
         }
-        return level.getBlockState(pos).is(block);
+        return WorldUtil.getBlockState(pos, (ServerLevel) level).is(block);
     }
 
     @Override

--- a/src/main/java/io/ticticboom/mods/mm/piece/type/port/PortStructurePiece.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/type/port/PortStructurePiece.java
@@ -12,10 +12,12 @@ import io.ticticboom.mods.mm.port.MMPortRegistry;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.structure.StructureModel;
 import io.ticticboom.mods.mm.util.PortUtils;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -55,7 +57,7 @@ public class PortStructurePiece extends StructurePiece {
 
     @Override
     public boolean formed(Level level, BlockPos pos, StructureModel model) {
-        var be = level.getBlockEntity(pos);
+        var be = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (be instanceof IPortBlockEntity pbe) {
             if (!pbe.getModel().id().equals(PortUtils.id(portId.getPath(), pbe.getModel().input()))) {
                 return false;
@@ -88,7 +90,7 @@ public class PortStructurePiece extends StructurePiece {
 
     @Override
     public JsonObject debugFound(Level level, BlockPos pos, StructureModel model, JsonObject json) {
-        var foundBlock = level.getBlockState(pos).getBlock();
+        var foundBlock = WorldUtil.getBlockState(pos, (ServerLevel) level).getBlock();
         var foundBlockId = ForgeRegistries.BLOCKS.getKey(foundBlock);
         json.addProperty("block", foundBlockId.toString());
         if (foundBlock instanceof IPortBlock pb) {

--- a/src/main/java/io/ticticboom/mods/mm/piece/type/porttype/PortTypeStructurePiece.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/type/porttype/PortTypeStructurePiece.java
@@ -10,10 +10,12 @@ import io.ticticboom.mods.mm.port.IPortBlockEntity;
 import io.ticticboom.mods.mm.port.MMPortRegistry;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.structure.StructureModel;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -53,7 +55,7 @@ public class PortTypeStructurePiece extends StructurePiece {
 
     @Override
     public boolean formed(Level level, BlockPos pos, StructureModel model) {
-        var be = level.getBlockEntity(pos);
+        var be = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (be instanceof IPortBlockEntity pbe) {
             if (!pbe.getModel().type().equals(portTypeId)) {
                 return false;
@@ -86,7 +88,7 @@ public class PortTypeStructurePiece extends StructurePiece {
 
     @Override
     public JsonObject debugFound(Level level, BlockPos pos, StructureModel model, JsonObject json) {
-        var foundBlock = level.getBlockState(pos).getBlock();
+        var foundBlock = WorldUtil.getBlockState(pos, (ServerLevel) level).getBlock();
         var foundBlockId = ForgeRegistries.BLOCKS.getKey(foundBlock);
         json.addProperty("block", foundBlockId.toString());
         if (foundBlock instanceof IPortBlock pb) {

--- a/src/main/java/io/ticticboom/mods/mm/piece/type/tag/TagStructurePiece.java
+++ b/src/main/java/io/ticticboom/mods/mm/piece/type/tag/TagStructurePiece.java
@@ -5,10 +5,12 @@ import com.google.gson.JsonObject;
 import io.ticticboom.mods.mm.piece.StructurePieceSetupMetadata;
 import io.ticticboom.mods.mm.piece.type.StructurePiece;
 import io.ticticboom.mods.mm.structure.StructureModel;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.Level;
@@ -41,7 +43,7 @@ public class TagStructurePiece extends StructurePiece {
 
     @Override
     public boolean formed(Level level, BlockPos pos, StructureModel model) {
-        var state = level.getBlockState(pos);
+        var state = WorldUtil.getBlockState(pos, (ServerLevel) level);
         return state.is(tagKey);
     }
 

--- a/src/main/java/io/ticticboom/mods/mm/port/botania/mana/BotaniaManaPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/botania/mana/BotaniaManaPortIngredient.java
@@ -26,6 +26,7 @@ public class BotaniaManaPortIngredient implements IPortIngredient {
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var inputs = storages.getInputStorages(BotaniaManaPortStorage.class);
         var remains = mana;
         for (BotaniaManaPortStorage input : inputs) {

--- a/src/main/java/io/ticticboom/mods/mm/port/botania/mana/register/BotaniaManaPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/botania/mana/register/BotaniaManaPortBlockEntity.java
@@ -53,6 +53,7 @@ public class BotaniaManaPortBlockEntity extends BlockEntity implements ManaPool,
     private final WandHud wandHud = new WandHud(this);
     private final LazyOptional<WandHUD> wandHudCap = LazyOptional.of(() -> wandHud);
     private final LazyOptional<ManaReceiver> manaReceiverCap = LazyOptional.of(() -> this);
+    private long lastTick = 0;
 
     public BotaniaManaPortBlockEntity(PortModel model, RegistryGroupHolder groupHolder, BlockPos pos, BlockState state) {
         super(groupHolder.getBe().get(), pos, state);
@@ -73,7 +74,9 @@ public class BotaniaManaPortBlockEntity extends BlockEntity implements ManaPool,
     }
 
     public void tick() {
-         boolean inNetwork = ManaNetworkHandler.instance.isPoolIn(level, this);
+        if(lastTick == level.getGameTime()) return;
+        lastTick = level.getGameTime();
+        boolean inNetwork = ManaNetworkHandler.instance.isPoolIn(level, this);
         if (!inNetwork && !this.isRemoved()) {
             BotaniaAPI.instance().getManaNetworkInstance().fireManaNetworkEvent(this, ManaBlockType.POOL, ManaNetworkAction.ADD);
         }

--- a/src/main/java/io/ticticboom/mods/mm/port/common/AbstractPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/common/AbstractPortBlockEntity.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractPortBlockEntity extends BlockEntity implements IPortBlockEntity, IPortPart {
 
+    protected long lastTick = 0;
     public AbstractPortBlockEntity(BlockEntityType<?> p_155228_, BlockPos p_155229_, BlockState p_155230_) {
         super(p_155228_, p_155229_, p_155230_);
     }

--- a/src/main/java/io/ticticboom/mods/mm/port/energy/EnergyPortHandler.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/energy/EnergyPortHandler.java
@@ -32,14 +32,20 @@ public class EnergyPortHandler extends EnergyStorage {
 
     @Override
     public int receiveEnergy(int maxReceive, boolean simulate) {
-        changed.call();
-        return super.receiveEnergy(maxReceive, simulate);
+        int result = super.receiveEnergy(maxReceive, simulate);
+        if (result > 0 && !simulate) {
+            changed.call();
+        }
+        return result;
     }
 
     @Override
     public int extractEnergy(int maxExtract, boolean simulate) {
-        changed.call();
-        return super.extractEnergy(maxExtract, simulate);
+        int result = super.extractEnergy(maxExtract, simulate);
+        if (result > 0 && !simulate) {
+            changed.call();
+        }
+        return result;
     }
 
 }

--- a/src/main/java/io/ticticboom/mods/mm/port/energy/EnergyPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/energy/EnergyPortIngredient.java
@@ -27,6 +27,7 @@ public class EnergyPortIngredient implements IPortIngredient {
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var inputStorages = storages.getInputStorages(EnergyPortStorage.class);
         int remaining = amount;
         for (EnergyPortStorage storage : inputStorages) {

--- a/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlock.java
@@ -8,8 +8,10 @@ import io.ticticboom.mods.mm.port.item.register.ItemPortBlockEntity;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.util.BlockUtils;
 import io.ticticboom.mods.mm.util.PortUtils;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -66,7 +68,7 @@ public class EnergyPortBlock extends Block implements IPortBlock, EntityBlock {
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
 
-        var thisBe = level.getBlockEntity(pos);
+        var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof EnergyPortBlockEntity pbe) {
             pbe.neighborsChanged();
         }

--- a/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlock.java
@@ -67,7 +67,7 @@ public class EnergyPortBlock extends Block implements IPortBlock, EntityBlock {
     @Override
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
-
+        if(level.isClientSide()) return;
         var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof EnergyPortBlockEntity pbe) {
             pbe.neighborsChanged();

--- a/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/energy/register/EnergyPortBlockEntity.java
@@ -126,6 +126,8 @@ public class  EnergyPortBlockEntity extends AbstractPortBlockEntity {
     }
 
     public void tick() {
+        if(lastTick == level.getGameTime()) return;
+        lastTick = level.getGameTime();
         autoPushAddon.ifPresent(EnergyPortAutoPushFeature::tick);
     }
 

--- a/src/main/java/io/ticticboom/mods/mm/port/fluid/FluidPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/fluid/FluidPortIngredient.java
@@ -39,6 +39,7 @@ public class FluidPortIngredient implements IPortIngredient {
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var fluidStorages = storages.getInputStorages(FluidPortStorage.class);
         int remaining = amount;
         for (FluidPortStorage storage : fluidStorages) {

--- a/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlock.java
@@ -93,7 +93,7 @@ public class FluidPortBlock extends Block implements IPortBlock, EntityBlock {
     @Override
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
-
+        if(level.isClientSide()) return;
         var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof FluidPortBlockEntity pbe) {
             pbe.neighborsChanged();

--- a/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlock.java
@@ -11,7 +11,9 @@ import io.ticticboom.mods.mm.port.item.register.ItemPortBlockEntity;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.util.BlockUtils;
 import io.ticticboom.mods.mm.util.PortUtils;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -72,7 +74,7 @@ public class FluidPortBlock extends Block implements IPortBlock, EntityBlock {
     }
 
     private IFluidHandler getHandler(Level level, BlockPos pos) {
-        BlockEntity blockEntity = level.getBlockEntity(pos);
+        BlockEntity blockEntity = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (blockEntity instanceof FluidPortBlockEntity pbe) {
             return ((FluidPortStorage) pbe.getStorage()).getWrappedHandler();
         }
@@ -92,7 +94,7 @@ public class FluidPortBlock extends Block implements IPortBlock, EntityBlock {
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
 
-        var thisBe = level.getBlockEntity(pos);
+        var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof FluidPortBlockEntity pbe) {
             pbe.neighborsChanged();
         }

--- a/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/fluid/register/FluidPortBlockEntity.java
@@ -98,6 +98,8 @@ public class FluidPortBlockEntity extends AbstractPortBlockEntity {
     }
 
     public void tick() {
+        if(lastTick == level.getGameTime()) return;
+        lastTick = level.getGameTime();
         autoPushAddon.ifPresent(FluidPortAutoPushFeature::tick);
     }
 

--- a/src/main/java/io/ticticboom/mods/mm/port/item/BaseItemPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/item/BaseItemPortIngredient.java
@@ -24,6 +24,7 @@ public abstract class BaseItemPortIngredient implements IPortIngredient {
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         List<ItemPortStorage> itemStorages = storages.getInputStorages(ItemPortStorage.class);
         int remaining = count;
         for (ItemPortStorage storage : itemStorages) {

--- a/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlock.java
@@ -8,7 +8,9 @@ import io.ticticboom.mods.mm.port.item.ItemPortStorage;
 import io.ticticboom.mods.mm.setup.RegistryGroupHolder;
 import io.ticticboom.mods.mm.util.BlockUtils;
 import io.ticticboom.mods.mm.util.PortUtils;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -60,7 +62,7 @@ public class ItemPortBlock extends Block implements IPortBlock, EntityBlock {
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean p_60519_) {
-        var be = level.getBlockEntity(pos);
+        var be = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (be instanceof ItemPortBlockEntity pbe) {
             var storage = (ItemPortStorage) pbe.getStorage();
             var handler = storage.getHandler();
@@ -83,7 +85,7 @@ public class ItemPortBlock extends Block implements IPortBlock, EntityBlock {
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
 
-        var thisBe = level.getBlockEntity(pos);
+        var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof ItemPortBlockEntity pbe) {
             pbe.neighborsChanged();
         }

--- a/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlock.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlock.java
@@ -84,7 +84,7 @@ public class ItemPortBlock extends Block implements IPortBlock, EntityBlock {
     @Override
     public void onNeighborChange(BlockState state, LevelReader level, BlockPos pos, BlockPos neighbor) {
         super.onNeighborChange(state, level, pos, neighbor);
-
+        if(level.isClientSide()) return;
         var thisBe = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
         if (thisBe instanceof ItemPortBlockEntity pbe) {
             pbe.neighborsChanged();

--- a/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/item/register/ItemPortBlockEntity.java
@@ -76,6 +76,8 @@ public class ItemPortBlockEntity extends AbstractPortBlockEntity {
     }
 
     public void tick() {
+        if(lastTick == level.getGameTime()) return;
+        lastTick = level.getGameTime();
         autoPushAddon.ifPresent(ItemPortAutoPushAddon::tick);
     }
 

--- a/src/main/java/io/ticticboom/mods/mm/port/kinetic/CreateKineticPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/kinetic/CreateKineticPortIngredient.java
@@ -25,6 +25,7 @@ public class CreateKineticPortIngredient implements IPortIngredient {
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var inputs = storages.getInputStorages(CreateKineticPortStorage.class);
         for (CreateKineticPortStorage input : inputs) {
             if (Math.abs(input.getSpeed()) >= Math.abs(speed)) {

--- a/src/main/java/io/ticticboom/mods/mm/port/kinetic/register/CreateKineticPortBlockEntity.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/kinetic/register/CreateKineticPortBlockEntity.java
@@ -20,6 +20,7 @@ public class CreateKineticPortBlockEntity extends KineticBlockEntity implements 
     private final PortModel model;
     private final RegistryGroupHolder groupHolder;
     private final CreateKineticPortStorage storage;
+    private long lastTick = 0;
 
     public CreateKineticPortBlockEntity(PortModel model, RegistryGroupHolder groupHolder, BlockPos pos, BlockState state) {
         super(groupHolder.getBe().get(), pos, state);
@@ -61,6 +62,8 @@ public class CreateKineticPortBlockEntity extends KineticBlockEntity implements 
 
     @Override
     public void tick() {
+        if(lastTick == level.getGameTime()) return;
+        lastTick = level.getGameTime();
         super.tick();
         storage.updateSpeed(speed);
     }

--- a/src/main/java/io/ticticboom/mods/mm/port/mekanism/chemical/MekanismChemicalPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/mekanism/chemical/MekanismChemicalPortIngredient.java
@@ -40,6 +40,7 @@ public abstract class MekanismChemicalPortIngredient<CHEMICAL extends Chemical<C
 
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var inputStorages = storages.getInputStorages(getStorageClass());
         long remaining = amount;
         for (MekanismChemicalPortStorage<CHEMICAL, STACK> storage : inputStorages) {

--- a/src/main/java/io/ticticboom/mods/mm/port/pneumaticcraft/air/PneumaticAirPortIngredient.java
+++ b/src/main/java/io/ticticboom/mods/mm/port/pneumaticcraft/air/PneumaticAirPortIngredient.java
@@ -23,6 +23,7 @@ public class PneumaticAirPortIngredient implements IPortIngredient {
     }
     @Override
     public boolean canProcess(Level level, RecipeStorages storages, RecipeStateModel state) {
+        if(storages == null) return false;
         var inputStorages = storages.getInputStorages(PneumaticAirPortStorage.class);
         for (PneumaticAirPortStorage storage : inputStorages) {
             if (storage.getPressure() < bar) {

--- a/src/main/java/io/ticticboom/mods/mm/recipe/MachineRecipeManager.java
+++ b/src/main/java/io/ticticboom/mods/mm/recipe/MachineRecipeManager.java
@@ -20,6 +20,7 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class MachineRecipeManager extends SimpleJsonResourceReloadListener {
     }
 
     public static final Map<ResourceLocation, RecipeModel> RECIPES = new HashMap<>();
+    public static final Map<String, Map<ResourceLocation, RecipeModel>> RECIPES_BY_STRUCTURE = new HashMap<>();
     public static final Map<ResourceLocation, IRecipeIngredientEntryParser> ENTRY_INGREDIENT_PARSERS = new HashMap<>();
     public static final Map<ResourceLocation, IRecipeOutputEntryParser> ENTRY_OUTPUT_PARSERS = new HashMap<>();
     public static final Map<ResourceLocation, IRecipeConditionParser> CONDITION_PARSERS = new HashMap<>();
@@ -65,6 +67,13 @@ public class MachineRecipeManager extends SimpleJsonResourceReloadListener {
         return RECIPES.values().stream().filter(x -> structureIds.contains(x.structureId())).toList();
     }
 
+    public static Collection<RecipeModel> getRecipesByStrucutreId(ResourceLocation id) {
+        if(RECIPES_BY_STRUCTURE.containsKey(id.toString())) {
+            return RECIPES_BY_STRUCTURE.get(id.toString()).values();
+        }
+        return List.of();
+    }
+
     @Override
     protected void apply(Map<ResourceLocation, JsonElement> jsons, ResourceManager resourceManager, ProfilerFiller profilerFiller) {
         profilerFiller.push("MM Machine Recipe Processes");
@@ -93,6 +102,14 @@ public class MachineRecipeManager extends SimpleJsonResourceReloadListener {
             }
         } catch (Exception e) {
             Ref.LCTX.doThrow(e);
+        }
+        cacheRecipesByStructure();
+    }
+
+    private static void cacheRecipesByStructure() {
+        RECIPES_BY_STRUCTURE.clear();
+        for (RecipeModel model : RECIPES.values()) {
+            RECIPES_BY_STRUCTURE.computeIfAbsent(model.structureId().toString(), x -> new HashMap<>()).put(model.id(), model);
         }
     }
 }

--- a/src/main/java/io/ticticboom/mods/mm/recipe/RecipeModel.java
+++ b/src/main/java/io/ticticboom/mods/mm/recipe/RecipeModel.java
@@ -43,10 +43,8 @@ public record RecipeModel(
             model.setCanProcess(false);
             return false;
         }
-        var canInput = inputs.canProcess(level, storages, model);
-        var canOutput = outputs.canProcess(level, storages, model);
-
-        boolean canProcessResult = canInput && canOutput;
+        //inputs first, if no inputs then quit early
+        boolean canProcessResult = inputs.canProcess(level, storages, model) && outputs.canProcess(level, storages, model);
         if (!canProcessResult) {
             model.setTickProgress(0);
         }

--- a/src/main/java/io/ticticboom/mods/mm/structure/layout/StructureLayout.java
+++ b/src/main/java/io/ticticboom/mods/mm/structure/layout/StructureLayout.java
@@ -114,7 +114,12 @@ public class StructureLayout {
         var outputStorages = new ArrayList<IPortStorage>();
         for (PositionedLayoutPiece positionedPiece : positionedPieces) {
             BlockPos absolutePos = positionedPiece.findAbsolutePos(worldControllerPos);
-            var be = level.getBlockEntity(absolutePos);
+            //this works faster
+            var be = level.getExistingBlockEntity(absolutePos);
+            if(be == null) {
+                //just in case of chunk unload
+                be = level.getBlockEntity(absolutePos);
+            }
             if (be instanceof IPortBlockEntity pbe) {
                 if (pbe.isInput()) {
                     inputStorages.add(pbe.getStorage());

--- a/src/main/java/io/ticticboom/mods/mm/structure/layout/StructureLayout.java
+++ b/src/main/java/io/ticticboom/mods/mm/structure/layout/StructureLayout.java
@@ -6,10 +6,12 @@ import io.ticticboom.mods.mm.port.IPortBlockEntity;
 import io.ticticboom.mods.mm.port.IPortStorage;
 import io.ticticboom.mods.mm.recipe.RecipeStorages;
 import io.ticticboom.mods.mm.structure.StructureModel;
+import io.ticticboom.mods.mm.util.WorldUtil;
 import lombok.Getter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Rotation;
 
@@ -118,7 +120,7 @@ public class StructureLayout {
             var be = level.getExistingBlockEntity(absolutePos);
             if(be == null) {
                 //just in case of chunk unload
-                be = level.getBlockEntity(absolutePos);
+                be = WorldUtil.getBlockEntity(absolutePos, (ServerLevel) level);
             }
             if (be instanceof IPortBlockEntity pbe) {
                 if (pbe.isInput()) {

--- a/src/main/java/io/ticticboom/mods/mm/util/BlockUtils.java
+++ b/src/main/java/io/ticticboom/mods/mm/util/BlockUtils.java
@@ -1,6 +1,7 @@
 package io.ticticboom.mods.mm.util;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
@@ -31,7 +32,7 @@ public class BlockUtils {
             preScreenCheck = () -> true;
         }
         if (!level.isClientSide() && hand == InteractionHand.MAIN_HAND) {
-            var be = level.getBlockEntity(pos);
+            var be = WorldUtil.getBlockEntity(pos, (ServerLevel) level);
             if (clz.isAssignableFrom(be.getClass())) {
                 if (preScreenCheck.get()) {
                     NetworkHooks.openScreen((ServerPlayer) player, (T) be, pos);

--- a/src/main/java/io/ticticboom/mods/mm/util/WorldUtil.java
+++ b/src/main/java/io/ticticboom/mods/mm/util/WorldUtil.java
@@ -1,0 +1,66 @@
+package io.ticticboom.mods.mm.util;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+
+import static net.minecraft.world.level.block.Blocks.AIR;
+
+/**
+ * Utility class for faster world-related operations.
+ */
+public class WorldUtil {
+
+    public static BlockState getBlockState(BlockPos pos, ServerLevel level) {
+        if (level == null) {
+            return AIR.defaultBlockState();
+        }
+
+        int chunkX = pos.getX() >> 4;
+        int chunkZ = pos.getZ() >> 4;
+        ChunkAccess chunk = getChunk(chunkX, chunkZ, level);
+
+        if (chunk == null) {
+            return AIR.defaultBlockState();
+        }
+
+        int sectionIndex = level.getSectionIndex(pos.getY());
+        if (sectionIndex < 0 || sectionIndex >= chunk.getSections().length) {
+            return AIR.defaultBlockState();
+        }
+
+        LevelChunkSection section = chunk.getSections()[sectionIndex];
+        if (section == null || section.hasOnlyAir()) {
+            return AIR.defaultBlockState();
+        }
+
+        int localX = pos.getX() & 15;
+        int localY = pos.getY() & 15;
+        int localZ = pos.getZ() & 15;
+
+        return section.getBlockState(localX, localY, localZ);
+    }
+
+    public static BlockEntity getBlockEntity(BlockPos pos, ServerLevel level) {
+        if (level == null) {
+            return null;
+        }
+
+        int chunkX = pos.getX() >> 4;
+        int chunkZ = pos.getZ() >> 4;
+        ChunkAccess chunk = getChunk(chunkX, chunkZ, level);
+
+        if (chunk == null) {
+            return null;
+        }
+
+        return chunk.getBlockEntity(pos);
+    }
+
+    public static ChunkAccess getChunk(int chunkX, int chunkZ, ServerLevel level) {
+        return level.getChunkSource().getChunk(chunkX, chunkZ, true);
+    }
+}


### PR DESCRIPTION
Tests in world with multiple structures:
With async validation (2% load) https://spark.lucko.me/PcxYTewF5i
Without async (4% load) https://spark.lucko.me/FnULXAAHBa
On servers with bunch of machines this could create a bigger difference.

Async validation creates some delay, as if you break a block of multiblock with recipe in progress, machine becomes invalid after async thread checks it. 
But i don't think this is a huge issue.

Anyways, if you don't like it, you can set default config value to false.